### PR TITLE
Update filter-setting workflow, notify users when their data is accessed

### DIFF
--- a/app/email.py
+++ b/app/email.py
@@ -1,6 +1,5 @@
 import resend
 from typing import List
-from fastapi import BackgroundTasks
 from urllib.parse import quote
 from dotenv import load_dotenv
 from os import getenv
@@ -37,3 +36,14 @@ def send_research_denial(recipient: str, name: str, req_msg: str, deny_msg: str)
         "Research account request denied",
         template_string("email/research_denial.html", context)
     )
+
+def send_data_access_notifs(userRows, instID: str, instName: str, count: int):
+    domain = getenv("APP_DOMAIN", "")
+    instURL = f"https://ror.org/{instID}"
+    for row in userRows:
+        context = {"name": row[1], "instName": instName, "instURL": instURL, "count": count, "domain": domain}
+        send_email(
+            [row[0]],
+            "Your data was accessed",
+            template_string("email/data_access_notif.html", context)
+        )

--- a/app/forms/account_config_form.py
+++ b/app/forms/account_config_form.py
@@ -10,6 +10,7 @@ class AccountConfigForm(BaseModel):
     current_password: str|None = None
     new_password: str|None = None
     public_enabled: bool|None = None
+    notif_enabled: bool|None = None
     birth_date: date|Literal['']|None = None
     gender: str|None = None
     med_conditions: str|None = None

--- a/app/forms/research_filter_form.py
+++ b/app/forms/research_filter_form.py
@@ -23,6 +23,12 @@ class ResearchFilterForm(BaseModel):
         if v == "" or v == []:
             return None
         return v
+    
+    @field_validator("date_from", "date_to")
+    @classmethod
+    def no_future_dates(cls, v):
+        if v is not None and v > date.today():
+            raise ValueError("Future dates are not allowed!")
 
     def to_json(self) -> str:
         return self.model_dump_json()

--- a/app/forms/signup_forms.py
+++ b/app/forms/signup_forms.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator, field_validator
 
 
 class StandardSignupForm(BaseModel):
@@ -35,6 +35,13 @@ class ResearchSignupRequestForm(BaseModel):
     email: EmailStr
     ror_id: Annotated[str, Field(min_length=3, max_length=512)]
     reason: Annotated[str, Field(min_length=5)]
+
+    @field_validator("ror_id", mode="after")
+    @classmethod
+    def trim_ror_url(cls, val: str):
+        if val.startswith("https://ror.org/"):
+            val = val[16:]
+        return val
 
 class ResearchSignupConfirmForm(BaseModel):
     """Research account confirmation form (step 2 of the account creation process)."""

--- a/app/main.py
+++ b/app/main.py
@@ -42,4 +42,4 @@ app.include_router(research.router)
 def validation_error_handler(request: Request, exc: RequestValidationError):
     for error in exc.errors():
         flash(request, f"Validation error for '{error['loc'][-1]}': {error['msg']}", "warn")
-    return RedirectResponse(request['path'], status_code=303)
+    return RedirectResponse(request.url, status_code=303)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,7 +2,7 @@ from .user import User
 from .researcher import Researcher
 from .dream_entry import DreamEntry
 from .tag import Tag
-from .download_record import DownloadRecord
+from .data_access_record import DataAccessRecord
 from .global_stats import GlobalStats
 from .tag_total import TagTotal
 from .tag_association import TagAssociation

--- a/app/models/data_access_record.py
+++ b/app/models/data_access_record.py
@@ -8,12 +8,12 @@ from ..database import Base
 if TYPE_CHECKING:
     from . import Researcher
 
-class DownloadRecord(Base):
-    __tablename__ = "download_records"
+class DataAccessRecord(Base):
+    __tablename__ = "data_access_records"
 
     id: Mapped[int] = mapped_column(primary_key=True)
     researcher_id: Mapped[int] = mapped_column(ForeignKey("researchers.id"))
-    downloaded_at: Mapped[datetime]
+    accessed_at: Mapped[datetime]
     filters_used: Mapped[str]
 
-    researcher: Mapped["Researcher"] = relationship(back_populates="downloads")
+    researcher: Mapped["Researcher"] = relationship(back_populates="data_accesses")

--- a/app/models/research_entry.py
+++ b/app/models/research_entry.py
@@ -12,8 +12,8 @@ class ResearchEntry(Base):
     __tablename__ = "research_entries"
     metadata = MetaData()
 
-    entry_id: Mapped[int]
-    title: Mapped[str] = mapped_column(primary_key=True)
+    entry_id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str]
     description: Mapped[str]
     content_tags: Mapped[str|None]
     type_tags: Mapped[str|None]
@@ -40,7 +40,7 @@ class ResearchEntry(Base):
     reflection: Mapped[str|None]
     rfln_timestamp: Mapped[datetime|None]
 
-    username: Mapped[str] = mapped_column(primary_key=True)
+    username: Mapped[str]
     user_age: Mapped[float|None]
     user_gender: Mapped[str|None]
     user_med_conditions: Mapped[str|None]

--- a/app/models/researcher.py
+++ b/app/models/researcher.py
@@ -27,16 +27,17 @@ class Researcher(Base):
     pw_hash: Mapped[str]
     email: Mapped[str] = mapped_column(unique=True)
     ror_id: Mapped[str]
+    pending_filters: Mapped[str|None]
     data_filters: Mapped[str|None]
 
     downloads: Mapped[List["DownloadRecord"]] = relationship(back_populates="researcher")
 
-    def filter_query(self, query: Select):
+    def filter_query(self, query: Select, pending: bool = False):
         """Filter a query on ``ResearchEntry`` using this account's saved filters (same rules as /research UI)."""
-        if not self.data_filters:
+        filtersRaw = self.pending_filters if pending else self.data_filters
+        if not filtersRaw:
             raise RuntimeError("This Researcher does not have any configured filters!")
-
-        filters: dict = json.loads(self.data_filters)
+        filters: dict = json.loads(filtersRaw)
 
         content_tags = filters.get("content_tags") or []
         if content_tags:
@@ -56,11 +57,11 @@ class Researcher(Base):
 
         date_from = filters.get("date_from")
         if date_from:
-            dt_from = date_str_to_datetime(date_from, False)
+            dt_from = date_str_to_datetime(date_from, max=False)
             query = query.where(ResearchEntry.created_at >= dt_from)
         date_to = filters.get("date_to")
         if date_to:
-            dt_to = date_str_to_datetime(date_to, True)
+            dt_to = date_str_to_datetime(date_to, max=True)
             query = query.where(ResearchEntry.created_at <= dt_to)
 
         age_min = filters.get("age_min")

--- a/app/models/researcher.py
+++ b/app/models/researcher.py
@@ -27,6 +27,7 @@ class Researcher(Base):
     pw_hash: Mapped[str]
     email: Mapped[str] = mapped_column(unique=True)
     ror_id: Mapped[str]
+    inst_name: Mapped[str]
     pending_filters: Mapped[str|None]
     data_filters: Mapped[str|None]
 

--- a/app/models/researcher.py
+++ b/app/models/researcher.py
@@ -61,9 +61,13 @@ class Researcher(Base):
             dt_from = date_str_to_datetime(date_from, max=False)
             query = query.where(ResearchEntry.created_at >= dt_from)
         date_to = filters.get("date_to")
+        cutoff = filters.get("cutoff_timestamp")
         if date_to:
             dt_to = date_str_to_datetime(date_to, max=True)
+            if cutoff and dt_to > cutoff: dt_to = cutoff
             query = query.where(ResearchEntry.created_at <= dt_to)
+        elif cutoff:
+            query = query.where(ResearchEntry.created_at <= cutoff)
 
         age_min = filters.get("age_min")
         if age_min is not None:

--- a/app/models/researcher.py
+++ b/app/models/researcher.py
@@ -11,7 +11,7 @@ from ..database import Base
 from .research_entry import ResearchEntry
 
 if TYPE_CHECKING:
-    from . import DownloadRecord, DreamEntry
+    from . import DataAccessRecord, DreamEntry
 
 
 def date_str_to_datetime(d: str, max: bool):
@@ -30,7 +30,7 @@ class Researcher(Base):
     pending_filters: Mapped[str|None]
     data_filters: Mapped[str|None]
 
-    downloads: Mapped[List["DownloadRecord"]] = relationship(back_populates="researcher")
+    data_accesses: Mapped[List["DataAccessRecord"]] = relationship(back_populates="researcher")
 
     def filter_query(self, query: Select, pending: bool = False):
         """Filter a query on ``ResearchEntry`` using this account's saved filters (same rules as /research UI)."""

--- a/app/models/researcher.py
+++ b/app/models/researcher.py
@@ -33,12 +33,29 @@ class Researcher(Base):
 
     data_accesses: Mapped[List["DataAccessRecord"]] = relationship(back_populates="researcher")
 
+    def get_last_access_dt(self):
+        """Get the timestamp of the latest data access request."""
+        if not self.data_accesses: return None
+        latest = datetime.min
+        for access in self.data_accesses:
+            if access.accessed_at > latest:
+                latest = access.accessed_at
+        return latest
+
     def filter_query(self, query: Select, pending: bool = False):
         """Filter a query on ``ResearchEntry`` using this account's saved filters (same rules as /research UI)."""
         filtersRaw = self.pending_filters if pending else self.data_filters
         if not filtersRaw:
             raise RuntimeError("This Researcher does not have any configured filters!")
         filters: dict = json.loads(filtersRaw)
+
+        # When filtering a real query, only entries that existed when the filters were locked in
+        # should be accessible. This prevents future entries from being included without the
+        # knowledge of their creators.
+        if not pending:
+            last_access = self.get_last_access_dt()
+            if last_access:
+                query = query.where(ResearchEntry.created_at <= last_access)
 
         content_tags = filters.get("content_tags") or []
         if content_tags:
@@ -61,13 +78,9 @@ class Researcher(Base):
             dt_from = date_str_to_datetime(date_from, max=False)
             query = query.where(ResearchEntry.created_at >= dt_from)
         date_to = filters.get("date_to")
-        cutoff = filters.get("cutoff_timestamp")
         if date_to:
             dt_to = date_str_to_datetime(date_to, max=True)
-            if cutoff and dt_to > cutoff: dt_to = cutoff
             query = query.where(ResearchEntry.created_at <= dt_to)
-        elif cutoff:
-            query = query.where(ResearchEntry.created_at <= cutoff)
 
         age_min = filters.get("age_min")
         if age_min is not None:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -20,6 +20,7 @@ class User(Base):
     pw_hash: Mapped[str]
     email: Mapped[str] = mapped_column(unique=True)
     public_enabled: Mapped[bool]
+    notif_enabled: Mapped[bool] = mapped_column(default=True)
     # additional optional details
     birth_date: Mapped[date|None]
     gender: Mapped[str|None]

--- a/app/routers/misc.py
+++ b/app/routers/misc.py
@@ -120,6 +120,8 @@ def account_config_action(request: Request, user: UserDep, dbSes: DbSesDep, form
                 flash(request, f"{len(public_entries)} public dream entries have been made private.", "info")
         
         user.public_enabled = formData.public_enabled
+    if formData.notif_enabled is not None:
+        user.notif_enabled = formData.notif_enabled
     if formData.birth_date is not None:
         user.birth_date = formData.birth_date or None
     if formData.gender is not None:

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -3,15 +3,16 @@ import csv
 import io
 import json
 from typing import Annotated, Sequence
-from fastapi import APIRouter, Request, Form
+from fastapi import BackgroundTasks, APIRouter, Request, Form
 from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy import select, func
 from datetime import datetime, date
 
-from ..models import Tag, ResearchEntry, DataAccessRecord
+from ..models import Tag, ResearchEntry, DataAccessRecord, User
 from ..forms import ResearchFilterForm
 from ..utils import ResearcherDep, DbSesDep, flash
 from ..jinja import templates
+from ..email import send_data_access_notifs
 
 router = APIRouter()
 
@@ -65,7 +66,13 @@ def research_filter_action(
 
 
 @router.post("/research/request")
-def research_request_data_action(request: Request, dbSes: DbSesDep, res: ResearcherDep):
+def research_request_data_action(
+    request: Request, 
+    bgTasks: BackgroundTasks, 
+    dbSes: DbSesDep, 
+    res: ResearcherDep,
+    row_count: Annotated[int, Form()]
+):
     if not res:
         flash(request, "This action requires a research account.", "warn")
         return RedirectResponse("/login", status_code=303)
@@ -87,8 +94,16 @@ def research_request_data_action(request: Request, dbSes: DbSesDep, res: Researc
         accessed_at=datetime.now(),
         filters_used=res.data_filters,
     ))
-
     dbSes.commit()
+
+    # send email notif to all matching users
+    notifQuery = res.filter_query(
+        select(User.email, User.username).distinct()
+        .where(User.notif_enabled)
+        .where(User.username == ResearchEntry.username)
+    )
+    userRows = dbSes.execute(notifQuery).all()
+    bgTasks.add_task(send_data_access_notifs, userRows, res.ror_id, res.inst_name, row_count)
 
     flash(request, "Request successful. You may now view and download your requested data.", "success")
     return RedirectResponse("/research", status_code=303)
@@ -196,19 +211,20 @@ def research_download_action(
         flash(request, "You have not yet requested access to any data!", "warn")
         return RedirectResponse("/research", status_code=303)
 
+    # retrieve all the data and convert it to CSV format
     dataQuery = res.filter_query(select(ResearchEntry).order_by(ResearchEntry.created_at.desc()))
     rows = dbSes.scalars(dataQuery).all()
     if not rows:
         flash(request, "No public entries match your current filters.", "warn")
         return RedirectResponse("/research/download", status_code=303)
+    csv_iter = generate_csv_iter(rows)
 
+    # define a filename
     safe_name = (filename or "").strip() or "nyctograph_entries.csv"
     if not safe_name.lower().endswith(".csv"):
         safe_name += ".csv"
 
-    csv_iter = generate_csv_iter(rows)
-
-    # StreamingResponse matches team guidance + FastAPI CSV patterns (no temp file on disk).
+    # send the CSV data to the client via a StreamingResponse
     headers = {"Content-Disposition": f'attachment; filename="{safe_name}"'}
     return StreamingResponse(
         csv_iter,

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -76,8 +76,9 @@ def research_request_data_action(request: Request, dbSes: DbSesDep, res: Researc
     
     # ensure that only currently existing entries are included
     parsedFilters = json.loads(res.pending_filters)
-    if parsedFilters["date_to"] is None:
-        parsedFilters["date_to"] = date.today().isoformat()
+    dateTo = parsedFilters["date_to"]
+    if dateTo is None or dateTo == date.today().isoformat():
+        parsedFilters["cutoff_timestamp"] = datetime.now().isoformat()
     res.data_filters = json.dumps(parsedFilters)
 
     # store a record of the data access for transparency purposes

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -8,7 +8,7 @@ from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy import select, func
 from datetime import datetime, date
 
-from ..models import Tag, ResearchEntry, DownloadRecord
+from ..models import Tag, ResearchEntry, DataAccessRecord
 from ..forms import ResearchFilterForm
 from ..utils import ResearcherDep, DbSesDep, flash
 from ..jinja import templates
@@ -79,6 +79,13 @@ def research_request_data_action(request: Request, dbSes: DbSesDep, res: Researc
     if parsedFilters["date_to"] is None:
         parsedFilters["date_to"] = date.today().isoformat()
     res.data_filters = json.dumps(parsedFilters)
+
+    # store a record of the data access for transparency purposes
+    dbSes.add(DataAccessRecord(
+        researcher_id=res.id,
+        accessed_at=datetime.now(),
+        filters_used=res.data_filters,
+    ))
 
     dbSes.commit()
 
@@ -199,15 +206,6 @@ def research_download_action(
         safe_name += ".csv"
 
     csv_iter = generate_csv_iter(rows)
-
-    dbSes.add(
-        DownloadRecord(
-            researcher_id=res.id,
-            downloaded_at=datetime.now(),
-            filters_used=res.data_filters or "{}",
-        )
-    )
-    dbSes.commit()
 
     # StreamingResponse matches team guidance + FastAPI CSV patterns (no temp file on disk).
     headers = {"Content-Disposition": f'attachment; filename="{safe_name}"'}

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -234,7 +234,7 @@ orderedColNames = [
     "title", "description", "content_tags", "type_tags", "sense_sight", "sense_sound", "sense_touch", 
     "sense_smell", "sense_taste", "sense_pain", "sense_other", "created_at", "context", "context_tags",
     "bed_time", "wake_time", "sleep_hours", "country", "state", "city", "not_at_home", "reflection", 
-    "rfln_timestamp", "username", "user_gender", "user_age", "user_med_conditions"
+    "rfln_timestamp", "user_gender", "user_age", "user_med_conditions"
 ]
 
 

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -81,12 +81,8 @@ def research_request_data_action(
         flash(request, "Please configure your filters before making a data request.", "warn")
         return RedirectResponse("/research", status_code=303)
     
-    # ensure that only currently existing entries are included
-    parsedFilters = json.loads(res.pending_filters)
-    dateTo = parsedFilters["date_to"]
-    if dateTo is None or dateTo == date.today().isoformat():
-        parsedFilters["cutoff_timestamp"] = datetime.now().isoformat()
-    res.data_filters = json.dumps(parsedFilters)
+    # lock in the filter settings
+    res.data_filters = res.pending_filters
 
     # store a record of the data access for transparency purposes
     dbSes.add(DataAccessRecord(
@@ -155,6 +151,7 @@ def research_data_page(
     entries = dbSes.execute(entries_query).scalars().all()
 
     return templates.TemplateResponse(request, "research-data.html", {
+        "request_dt": res.get_last_access_dt(),
         "entries": entries,
         "page": page,
         "per_page": per_page,

--- a/app/routers/research.py
+++ b/app/routers/research.py
@@ -1,11 +1,12 @@
 import math
 import csv
 import io
+import json
 from typing import Annotated, Sequence
 from fastapi import APIRouter, Request, Form
 from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy import select, func
-from datetime import datetime
+from datetime import datetime, date
 
 from ..models import Tag, ResearchEntry, DownloadRecord
 from ..forms import ResearchFilterForm
@@ -20,16 +21,16 @@ def research_filter_page(request: Request, res: ResearcherDep, dbSes: DbSesDep):
         flash(request, "This page requires a research account.", "warn")
         return RedirectResponse("/login", status_code=303)
 
-    current_filters = ResearchFilterForm.from_json(res.data_filters)
+    current_filters = ResearchFilterForm.from_json(res.pending_filters)
 
     all_tags = dbSes.execute(select(Tag)).scalars().all()
     content_tags = [t.value for t in all_tags if t.category == "dream_content"]
     type_tags = [t.value for t in all_tags if t.category == "dream_type"]
     context_tags = [t.value for t in all_tags if t.category == "irl_context"]
 
-    if res.data_filters:
+    if res.pending_filters:
         countQuery = select(func.count()).select_from(ResearchEntry)
-        matchQuery = res.filter_query(countQuery)
+        matchQuery = res.filter_query(countQuery, pending=True)
         total_count = dbSes.execute(countQuery).scalar()
         match_count = dbSes.execute(matchQuery).scalar()
     else:
@@ -42,6 +43,7 @@ def research_filter_page(request: Request, res: ResearcherDep, dbSes: DbSesDep):
         "context_tags": context_tags,
         "match_count": match_count,
         "total_count": total_count,
+        "today": date.today()
     })
 
 
@@ -53,13 +55,36 @@ def research_filter_action(
     formData: Annotated[ResearchFilterForm, Form()],
 ):
     if not res:
-        flash(request, "This page requires a research account.", "warn")
+        flash(request, "This action requires a research account.", "warn")
         return RedirectResponse("/login", status_code=303)
 
-    res.data_filters = formData.to_json()
+    res.pending_filters = formData.to_json()
     dbSes.commit()
     flash(request, "Filters saved.", "success")
     return RedirectResponse("/research", status_code=303)
+
+
+@router.post("/research/request")
+def research_request_data_action(request: Request, dbSes: DbSesDep, res: ResearcherDep):
+    if not res:
+        flash(request, "This action requires a research account.", "warn")
+        return RedirectResponse("/login", status_code=303)
+    
+    if not res.pending_filters:
+        flash(request, "Please configure your filters before making a data request.", "warn")
+        return RedirectResponse("/research", status_code=303)
+    
+    # ensure that only currently existing entries are included
+    parsedFilters = json.loads(res.pending_filters)
+    if parsedFilters["date_to"] is None:
+        parsedFilters["date_to"] = date.today().isoformat()
+    res.data_filters = json.dumps(parsedFilters)
+
+    dbSes.commit()
+
+    flash(request, "Request successful. You may now view and download your requested data.", "success")
+    return RedirectResponse("/research", status_code=303)
+
 
 def _page_range(page: int, total_pages: int) -> list[int]:
     """Return page numbers to display, using -1 as an ellipsis marker."""
@@ -90,7 +115,7 @@ def research_data_page(
         return RedirectResponse("/login", status_code=303)
 
     if not res.data_filters:
-        flash(request, "Please configure your research filters before viewing data.", "warn")
+        flash(request, "You have not yet requested access to any data!", "warn")
         return RedirectResponse("/research", status_code=303)
 
     if per_page not in (10, 25, 50):
@@ -123,8 +148,8 @@ def research_download_page(request: Request, dbSes: DbSesDep, res: ResearcherDep
         return RedirectResponse("/login", status_code=303)
 
     if not res.data_filters:
-        flash(request, "No requested data. Set filters first.", "warn")
-        return templates.TemplateResponse(request, "download-requested-data.html", {"has_data": False})
+        flash(request, "You have not yet requested access to any data!", "warn")
+        return RedirectResponse("/research", status_code=303)
 
     countQuery = res.filter_query(select(func.count()).select_from(ResearchEntry))
     sampleQuery = res.filter_query(select(ResearchEntry).order_by(func.random()).limit(10))
@@ -132,13 +157,13 @@ def research_download_page(request: Request, dbSes: DbSesDep, res: ResearcherDep
     sampleRows = dbSes.scalars(sampleQuery).all()
     if not count:
         flash(request, "No public entries match your current filters.", "warn")
-        return templates.TemplateResponse(request, "download-requested-data.html", {"has_data": False})
+        return templates.TemplateResponse(request, "research-download.html", {"has_data": False})
 
     estSizeBytes = estimate_download_size(sampleRows, count)
 
     return templates.TemplateResponse(
         request,
-        "download-requested-data.html",
+        "research-download.html",
         {
             "has_data": True,
             "row_count": count,
@@ -160,8 +185,8 @@ def research_download_action(
         return RedirectResponse("/login", status_code=303)
 
     if not res.data_filters:
-        flash(request, "No requested data. Set filters first.", "warn")
-        return RedirectResponse("/research/download", status_code=303)
+        flash(request, "You have not yet requested access to any data!", "warn")
+        return RedirectResponse("/research", status_code=303)
 
     dataQuery = res.filter_query(select(ResearchEntry).order_by(ResearchEntry.created_at.desc()))
     rows = dbSes.scalars(dataQuery).all()
@@ -216,13 +241,12 @@ def estimate_download_size(sampleRows: Sequence[ResearchEntry], totalRows: int) 
     # Write them to a test CSV
     buf = io.StringIO()
     writer = csv.DictWriter(buf, fieldnames=orderedColNames, extrasaction="ignore")
-    writer.writeheader()
     writer.writerows(map(lambda entry: entry.__dict__, sampleRows))
 
-    # Estimate size of full CSV (the +1 is because of the header row)
+    # Estimate size of full CSV (the extra 295 bytes is for the header)
     full = buf.getvalue()
-    avgPerRow = len(full.encode("utf-8")) / (len(sampleRows)+1)
-    return int(avgPerRow * (totalRows+1))
+    avgPerRow = len(full.encode("utf-8")) / len(sampleRows)
+    return int(avgPerRow * totalRows) + 295
 
 
 # Convert a list of ResearchEntry objects into a StringIO representing a CSV file.

--- a/app/routers/signup.py
+++ b/app/routers/signup.py
@@ -1,5 +1,5 @@
+import requests
 from typing import Annotated
-
 from fastapi import APIRouter, Request, Form
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select
@@ -75,6 +75,12 @@ def research_signup_action(
     if existingReq is not None:
         flash(request, "There is already a pending request with that email - please wait for us to review it.", "warn")
         return RedirectResponse("/signup/research", status_code=303)
+    
+    # make sure ROR ID actually exists
+    rorLookup: dict = requests.get(f"https://api.ror.org/v2/organizations/{form.ror_id}").json()
+    if "errors" in rorLookup:
+        flash(request, "That is not a valid ROR ID.", "warn")
+        return RedirectResponse("/signup/research", status_code=303)
 
     newReq = ResearchRequest(
         name=form.name,
@@ -107,12 +113,23 @@ def research_confirmation_action(
     if req is None:
         flash(request, "Invalid account token. You must request a research account and be approved before you can create the account.", "warn")
         return RedirectResponse("/signup/research", status_code=303)
+    
+    # look up institution name from ROR
+    rorLookup: dict = requests.get(f"https://api.ror.org/v2/organizations/{req.ror_id}").json()
+    if "errors" in rorLookup:
+        flash(request, "Your account request somehow has an invalid ROR ID.", "warn")
+        return RedirectResponse("/signup/research", status_code=303)
+    instName = "[Name not found]"
+    for name in rorLookup["names"]:
+        if "ror_display" in name["types"]:
+            instName = name["value"]
 
     researcher = Researcher(
         username=form.username,
         pw_hash=ph.hash(form.password),
         email=req.email,
-        ror_id=req.ror_id
+        ror_id=req.ror_id,
+        inst_name=instName
     )
     dbSes.add(researcher)
     dbSes.delete(req)

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -19,16 +19,25 @@
         <input type="password" id="new_password" name="new_password">
         <br><br>
 
-        <h2>Profile Details</h2>
+        <h2>Privacy Settings</h2>
         <label for="public_enabled">Allow my dream data to be included in global statistics and made available to researchers</label>
         <br>
-        <input type="radio" id="public_yes" name="public_enabled" value="True" onclick="showInfo(true)" required {%if user.public_enabled%}checked{%endif%}>
+        <input type="radio" id="public_yes" name="public_enabled" value="True" required {%if user.public_enabled%}checked{%endif%}>
         <label for="public_yes">Yes</label>
-        <input type="radio" id="public_no" name="public_enabled" value="False" onclick="showInfo(false)" required {%if not user.public_enabled%}checked{%endif%}>
+        <input type="radio" id="public_no" name="public_enabled" value="False" required {%if not user.public_enabled%}checked{%endif%}>
         <label for="public_no">No</label>
         <br>
         <label style="font-size: 0.95em; color: #666;">(Entries still need to be individually marked as public for the above to apply)</label>
         <br><br>
+        <label for="notif_enabled">Notify me when my dream entries are included in a dataset provided to a researcher</label>
+        <br>
+        <input type="radio" id="notif_yes" name="notif_enabled" value="True" required {%if user.notif_enabled%}checked{%endif%}>
+        <label for="notif_yes">Yes</label>
+        <input type="radio" id="notig_no" name="notif_enabled" value="False" required {%if not user.notif_enabled%}checked{%endif%}>
+        <label for="notif_no">No</label>
+        <br><br>
+
+        <h2>Profile Details</h2>
         <label for="birth_date">Birth date:</label>
         <input type="date" id="birth_date" name="birth_date" value="{{ user.birth_date if user.birth_date is not none }}">
         <br>

--- a/app/templates/dream-detail.html
+++ b/app/templates/dream-detail.html
@@ -10,7 +10,6 @@
     <section>
         <h2>Basic Information</h2>
         <p><strong>Created:</strong> {{ entry.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</p>
-        <p><strong>Author:</strong> {{ entry.user.username }}</p>
         <p>
             <strong>Visibility:</strong> {{ "Public" if entry.public else "Private" }}
             {% if is_owner %}

--- a/app/templates/email/data_access_notif.html
+++ b/app/templates/email/data_access_notif.html
@@ -1,0 +1,12 @@
+{% extends "email/email_base.html" %}
+{% block body %}
+    <p>
+        One or more of your dream entries was just included in a research dataset containing {{count}} total entries.<br>
+        The dataset was requested by a researcher at <a href="{{instURL}}">{{instName}}</a>.
+    </p>
+    <p>You can learn more about what we do with your data <a href="{{domain}}/about-us">here</a>.</p>
+    <p style="font-size:0.9em">
+        If you no longer wish to be notified when your dream entries are included in datasets, 
+        disable this feature in <a href="{{domain}}/account">account settings</a>.
+    </p>
+{% endblock %}

--- a/app/templates/research-data.html
+++ b/app/templates/research-data.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% block body %}
     <h1>View Requested Data</h1>
-    <p>You currently have access to <strong>{{ total_count }}</strong> public dream entr{{ "y" if total_count == 1 else "ies" }}.</p>
+    <p>
+        You currently have access to <strong>{{ total_count }}</strong> public dream entr{{ "y" if total_count == 1 else "ies" }},
+        based on your request at {{ request_dt.strftime('%I:%M %p on %Y-%m-%d') }}.<br>
+        Entries created after that date and time are not accessible, even if they match your filters.
+    </p>
 
     <div>
         <strong>Entries per page:</strong>

--- a/app/templates/research-data.html
+++ b/app/templates/research-data.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
-    <h1>Research Data</h1>
-    <p>
-        <strong>{{ total_count }}</strong> entr{{ "y" if total_count == 1 else "ies" }} match your saved filters.
-        <a href="/research">Edit filters</a>
-    </p>
+    <h1>View Requested Data</h1>
+    <p>You currently have access to <strong>{{ total_count }}</strong> public dream entr{{ "y" if total_count == 1 else "ies" }}.</p>
 
     <div>
         <strong>Entries per page:</strong>

--- a/app/templates/research-data.html
+++ b/app/templates/research-data.html
@@ -26,9 +26,9 @@
         <thead>
             <tr>
                 <th>Title</th>
-                <th>Author</th>
                 <th>Date</th>
                 <th>Location</th>
+                <th>At Home?</th>
                 <th>Senses</th>
                 <th>Content Tags</th>
                 <th>Type Tags</th>
@@ -44,9 +44,9 @@
             {% for entry in entries %}
             <tr style="cursor:pointer" onclick="window.location='/my-dreams/{{ entry.entry_id }}'">
                 <td><a href="/my-dreams/{{ entry.entry_id }}">{{ entry.title }}</a></td>
-                <td>{{ entry.username }}</td>
                 <td>{{ entry.created_at.strftime('%Y-%m-%d') }}</td>
                 <td style="white-space:normal">{{ [entry.city, entry.state, entry.country]|reject('none')|join(', ') }}</td>
+                <td style="white-space:normal">{{"No" if entry.not_at_home else "Yes"}}</td>
                 <td>{{ ('👁️' if entry.sense_sight else '')+
                        ('👂' if entry.sense_sound else '')+
                        ('🫳' if entry.sense_touch else '')+

--- a/app/templates/research-download.html
+++ b/app/templates/research-download.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body %}
-  <h1>Download requested data (research)</h1>
+  <h1>Download Requested Data</h1>
 
   {% if not has_data %}
     <p>No downloadable data available yet.</p>

--- a/app/templates/research.html
+++ b/app/templates/research.html
@@ -6,6 +6,7 @@
     {% else %}
         <p><strong>{{ match_count }}</strong> of <strong>{{ total_count }}</strong> public entries match your currently selected filters.</p>
         <form id="request_data" action="/research/request" method="post" onsubmit="return confirm('Are you sure these filters are correct? This will permanently replace any data you\'ve previously requested.');">
+            <input type="hidden" name="row_count" value="{{ match_count }}">
             <label for="submit_request">Request access to view and download these <strong>{{ match_count }}</strong> entries?</label>
             <input id="submit_request" type="submit" value="Request" {{ disabled if total_count == None }}>
             <br>

--- a/app/templates/research.html
+++ b/app/templates/research.html
@@ -1,13 +1,23 @@
 {% extends "base.html" %}
 {% block body %}
-    <h1>Research Filters</h1>
+    <h1>Research Data Request</h1>
     {% if total_count == None %}
-        <p>You do not have any saved filters yet. Choose some below, then press 'Save filters' to save them.</p>
+        <p>You do not have any filters selected yet. Choose some below, then press 'Update filters' to save them.</p>
     {% else %}
-        <p><strong>{{ match_count }}</strong> of <strong>{{ total_count }}</strong> public entries match your currently saved filters.</p>
+        <p><strong>{{ match_count }}</strong> of <strong>{{ total_count }}</strong> public entries match your currently selected filters.</p>
+        <form id="request_data" action="/research/request" method="post" onsubmit="return confirm('Are you sure these filters are correct? This will permanently replace any data you\'ve previously requested.');">
+            <label for="submit_request">Request access to view and download these <strong>{{ match_count }}</strong> entries?</label>
+            <input id="submit_request" type="submit" value="Request" {{ disabled if total_count == None }}>
+            <br>
+            <label style="font-size: 0.95em; color: #666;">(This will replace any data you've previously requested)</label>
+        </form>
+        <p id="dirty" style="color:red" hidden>
+            The filters chosen below are <strong>not</strong> yet saved! 
+            Press 'Update filters' to save them before making a data request.
+        </p>
     {% endif %}
-    <p id="dirty" style="color:red" hidden>The filters selected below are <strong>not</strong> yet saved!</p>
 
+    <h1>Filter Configuration</h1>
     <form id="update_filters" action="" method="post">
         <h2>Dream Entry Tags</h2>
         <p>Entries will be included if they have at least one of the selected tags. Leave all unchecked to include any.</p>
@@ -45,10 +55,10 @@
         <h2>Date Range</h2>
         <p>Leave blank to ignore entry timestamps.</p>
         <label for="date_from">From:</label>
-        <input type="date" id="date_from" name="date_from"
+        <input type="date" id="date_from" name="date_from" max="{{today}}"
             value="{{ filters.date_from if filters.date_from is not none }}">
         <label for="date_to">To:</label>
-        <input type="date" id="date_to" name="date_to"
+        <input type="date" id="date_to" name="date_to" max="{{today}}"
             value="{{ filters.date_to if filters.date_to is not none }}">
         <br><br>
 
@@ -111,7 +121,7 @@
         <label for="rfln-no">Without a reflection only</label>
         <br><br>
 
-        <input type="submit" value="Save filters">
+        <input type="submit" value="Update filters">
     </form>
 
     <script>


### PR DESCRIPTION
After a researcher saves their filters, they now have to perform the additional step of making an official request using those filters. Only then will they be able to view and/or download their requested data.

When this happens, users whose entries match the filters will be informed via email that their data has been accessed (this can be disabled in account settings for those who don't want to get emails). This request step is also where the paywall will go, once that gets implemented.

To go along with this change, researchers will now only have access to entries created _before_ they made their request. This way, it won't be possible for an entry to be included in a dataset without its creator's knowledge because it matched the filters but was created after the access notification had already been sent out.

This PR also adds verification for the ROR ID, since it gets included in the notification email and thus it must be valid.